### PR TITLE
Added history functionality to search queries on the plugin page

### DIFF
--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -73,12 +73,30 @@
         searchClass: 'search-query'
       });
 
+      var searchTimer;
+      var baseURL = document.URL.split('/').slice(0,4).join('/');
       $searchQuery.removeProp('disabled').focus()
       .on('submit', false)
       .on('keyup paste', function () {
         // disable contrib first, if searching
         if ($contribCheck.is(':checked')) $contribCheck.trigger('click');
-        list.search( $(this).val());
+        var query = $(this).val();
+        list.search( query );
+        // wait .75 seconds to update location so it's not every keystroke
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(function () {
+          if (history && history.pushState) history.pushState({ page: query }, query, baseURL+'/'+query );
+        },750);
+      });
+      // update query value on popstate
+      $(window).on('popstate', function () {
+        if(history.state) {
+          $searchQuery.val(history.state.page);
+        } else {
+          $searchQuery.val('');
+        }
+        // execute the search
+        list.search( $searchQuery.val() );
       });
 
       $('#plugins-all .modified time, #plugins-contrib .modified time').timeago();


### PR DESCRIPTION
Added basic history.pushState functionality to the plugin search. A .75s delay occurs before history.pushState is called to allow time for typing. Uses existing pattern where the string after 'plugins/' is used as the state value. Used window.onpopstate event to update the list and field.

I added this mainly because I was tired of having to re-type my search every time I pressed the back button after investigating a package.
