### PR TITLE
Add grunt-contrib-eslint to the blacklist

### DIFF
--- a/grunt-plugins.js
+++ b/grunt-plugins.js
@@ -17,7 +17,8 @@ var bannedPlugins = [
   'dp-grunt-contrib-copy',
   'grunt-test',
   'grunt-testingoscar123',
-  'assemble-less-variables'
+  'assemble-less-variables',
+  'grunt-contrib-eslint'
 ];
 
 var pluginFile = 'build/plugin-list.json';


### PR DESCRIPTION
https://github.com/gyandeeps/grunt-contrib-eslint
- Violates [plugin naming guideline](http://gruntjs.com/creating-plugins#naming-your-task)
- Nearly the same as [grunt-eslint](https://github.com/sindresorhus/grunt-eslint)
