### PR TITLE
Include a npm/github description on release versions

### DIFF
--- a/src/tmpl/index.jade
+++ b/src/tmpl/index.jade
@@ -127,9 +127,11 @@ block content
               li Stable:
                 = ' '
                 a(href='https://www.npmjs.org/package/grunt') v0.4.5
+                span  (npm)
               li Development:
                 = ' '
                 a(href='https://github.com/gruntjs/grunt') v0.4.6
+                span  (github)
 
           include blocks/advertisements
 


### PR DESCRIPTION
Fixes #135

The 2 spaces after `span` is to force a space on the html visualization
