### PR TITLE
npm install the wrong grunt-docs plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-less": "~0.5.2",
     "grunt-contrib-uglify": "~0.3.3",
-    "grunt-docs": "^0.2.0",
+    "grunt-docs": "https://github.com/gruntjs/grunt-docs/tarball/master",
     "highlight.js": "~7.3.0",
     "jade": "~0.35.0",
     "lodash": "~1.0.1",


### PR DESCRIPTION
On www.npmjs.org the grunt-docs package is registered by shama's grunt-plugin https://github.com/shama/grunt-docs, but not the gruntjs team's grunt-plugin https://github.com/gruntjs/grunt-docs, so when I run `npm install` under the gruntjs.com project folder, npm install the wrong grunt-docs plugin, then when running the grunt task, grunt-docs goes wrong.  Correct this by specifying the grunt-docs tarball url !
