### PR TITLE
Migrate links to www.npmjs.com domain

### DIFF
--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -38,7 +38,7 @@
           var author = (full.a && full.a.length > 0) ? ('by ' + full.a) : '';
 
           var tmpl = '';
-          tmpl += '<a class="plugin ' + (isContrib ? 'contrib' : '') + '" href="https://npmjs.org/package/' + data + '">';
+          tmpl += '<a class="plugin ' + (isContrib ? 'contrib' : '') + '" href="https://www.npmjs.com/package/' + data + '">';
           tmpl += '<span class="name-description">';
           tmpl += '<span class="title">' + name + '</span>';
           tmpl += '<span class="author">' + author + '</span>';

--- a/src/tmpl/index.jade
+++ b/src/tmpl/index.jade
@@ -25,28 +25,28 @@ block content
             h2 Available Grunt plugins
             p Many of the tasks you need are already available as Grunt Plugins, and new plugins are published every day. While the <a href="/plugins">plugin listing</a> is more complete, here's a few you may have heard of.
             div
-              a.technology(href='https://npmjs.org/package/grunt-contrib-coffee')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-coffee')
                 span.logo
                   img(src='/img/logo-coffeescript.jpg', alt='CoffeeScript')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-handlebars')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-handlebars')
                 span.logo
                   img(src='/img/logo-handlebars.jpg', alt='Handlebars')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-jade')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-jade')
                 span.logo
                   img(src='/img/logo-jade.jpg', alt='Jade')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-jshint')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-jshint')
                 span.logo
                   img(src='/img/logo-jshint.jpg', alt='JSHint')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-less')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-less')
                 span.logo
                   img(src='/img/logo-less.jpg', alt='Less')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-requirejs')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-requirejs')
                 span.logo
                   img(src='/img/logo-requirejs.jpg', alt='Require.js')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-sass')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-sass')
                 span.logo
                   img(src='/img/logo-sass.jpg', alt='Sass')
-              a.technology(href='https://npmjs.org/package/grunt-contrib-stylus')
+              a.technology(href='https://www.npmjs.com/package/grunt-contrib-stylus')
                 span.logo
                   img(src='/img/logo-sylus.jpg', alt='Stylus')
 


### PR DESCRIPTION
Hi,

- It looks like their .org certificate expired.
- I kept "api.npmjs.org" use because api.npmjs.com isn't available.

Thanks.