### PR TITLE
Removed redundant "Documentation" anchor

### DIFF
--- a/src/tmpl/blocks/header.jade
+++ b/src/tmpl/blocks/header.jade
@@ -14,10 +14,6 @@
               i.icon-power-cord
               span Plugins
           li
-            a(href='/getting-started')
-              i.icon-document-alt-stroke
-              span Documentation
-          li
             a(href='/api')
               i.icon-cog
               span API


### PR DESCRIPTION
Removed redundant "Documentation" anchor that hreffed to '/getting-started' already pointed by Getting Started.