### PR TITLE
Add `contrib-appbuilder` to the blacklist

### DIFF
--- a/grunt-plugins.js
+++ b/grunt-plugins.js
@@ -76,7 +76,8 @@ var bannedPlugins = [
   'grunt-contrib-litchi', // Reason: unofficial contrib plugin
   'grunt-contrib-remotecordova', // Reason: unofficial contrib plugin
   'grunt-contrib-environment', // Reason: unofficial contrib plugin
-  'grunt-contrib-lessify' // Reason: unofficial contrib plugin
+  'grunt-contrib-lessify', // Reason: unofficial contrib plugin
+  'grunt-contrib-appbuilder' // Reason: unofficial contrib plugin
 ];
 
 var pluginFile = 'build/plugin-list.json';


### PR DESCRIPTION
Another one with an incorrect `contrib` prefix. I opened an issue a while ago but the author never responded: https://github.com/tgardner/grunt-contrib-appbuilder/issues/1.