### PR TITLE
Updated `grunt-docs` to latest commit dede869

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-less": "~0.5.2",
     "grunt-contrib-uglify": "~0.3.3",
-    "grunt-docs": "git://github.com/gruntjs/grunt-docs#6fd648a636a",
+    "grunt-docs": "git://github.com/gruntjs/grunt-docs#dede869cf3068b5afa8e192e2b1ea2c4481366e9",
     "highlight.js": "~7.3.0",
     "jade": "~0.35.0",
     "lodash": "~1.0.1",


### PR DESCRIPTION
- Update `grunt-docs` to latest commit [dede869](https://github.com/gruntjs/grunt-docs/commit/dede869cf3068b5afa8e192e2b1ea2c4481366e9) (dede869cf3068b5afa8e192e2b1ea2c4481366e9)