### PR TITLE
Moving blog entries into a single `blog/` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-less": "~0.5.2",
     "grunt-contrib-uglify": "~0.3.3",
-    "grunt-docs": "git://github.com/gruntjs/grunt-docs#6a381e5fc90671a85c820685f6db90838fde6537",
+    "grunt-docs": "git://github.com/gruntjs/grunt-docs#4eab0683f13e6fb251f4bd66d951927ca12dca95",
     "highlight.js": "~7.3.0",
     "jade": "~0.35.0",
     "lodash": "~1.0.1",

--- a/tasks/blog.js
+++ b/tasks/blog.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
     var names;
     var shortList = [];
     var articleList = [];
-    var base = 'node_modules/grunt-docs/';
+    var base = 'node_modules/grunt-docs/blog/';
     var files = grunt.file.expand({cwd:base}, ['Blog-*.md']);
 
     names = files.map(function (name) {

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
 
         // API Docs
         var sidebars = [];
-        var names = grunt.file.expand({cwd:base}, ['*', '!Blog-*', '!grunt*.md', '!*.js']);
+        var names = grunt.file.expand({cwd:base}, ['*', '!blog/**', '!grunt*.md', '!*.js']);
 
         sidebars[0] = getSidebarSection('## Documentation', 'icon-document-alt-stroke');
         sidebars[1] = getSidebarSection('### Advanced');


### PR DESCRIPTION
As we gradually add more and more blog entries, it will become increasingly difficult to manage the grunt-docs, as most of the documentation's source files falls after the letter "b" (and we have to scroll heaps to find the files we need to edit). Organising blog entries into the same `blog/` folder could help manage the repository better.

## IMPORTANT
This pull request is tied to a pull request in another repository. Merging this pull request must follow a precise sequence of events:
- [ ] FIRST merge [the other pull request](https://github.com/gruntjs/grunt-docs/pull/165) into the `gruntjs/grunt-docs` repository, and note the latest commit code
- [ ] SECONDLY merge THIS pull request into the `gruntjs/gruntjs.com` repository
- [ ] Update the [`gruntjs/gruntjs.com/package.json`](https://github.com/gruntjs/gruntjs.com/blob/master/package.json) file in THIS repository, so the "grunt-docs" URL has the latest commit code (noted from the first checkbox)