### PR TITLE
Update Font to load over HTTPS and update to X-UA-Compatible meta tag

### DIFF
--- a/src/tmpl/layout.jade
+++ b/src/tmpl/layout.jade
@@ -2,10 +2,10 @@
 html(lang='en')
   head
     meta(charset='utf-8')
-    meta(http-equiv='X-UA-Compatible', content='IE=edge,chrome=1')
+    meta(http-equiv='X-UA-Compatible', content='IE=edge')
     title= (locals.title ? locals.title + ' - ' : '') + 'Grunt: The JavaScript Task Runner'
     link(rel='stylesheet', href='/css/main.css')
-    link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lato:400,700')
+    link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Lato:400,700')
     link(rel='shortcut icon', href='../img/favicon.ico', type='image/x-icon')
     link(href='/rss', rel='alternate', title='Grunt Blog Feed', type='application/atom+xml')
     script(src='/js/vendor/lib/modernizr.min.js')


### PR DESCRIPTION
- Update Font to load over HTTPS as recommended by Google
- Remove unneeded chrome=1 from the X-UA-Compatible meta tag as that was only ever needed for Chrome Frame for old Internet Explorer. Chrome Frame was discontinued years ago and is no longer available.