### PR TITLE
Enable sourcemaps.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,10 @@ module.exports = function(grunt) {
     },
 
     less: {
+      options: {
+        sourceMap: true,
+        outputSourceFiles: true
+      },
       development: {
         options: {
           paths: ['src/less']
@@ -61,6 +65,10 @@ module.exports = function(grunt) {
     },
 
     uglify: {
+      options: {
+        sourceMap: true,
+        sourceMapIncludeSources: true
+      },
       plugins: {
         src: [
           'src/js/vendor/lib/jquery.js',
@@ -129,7 +137,7 @@ module.exports = function(grunt) {
     },
 
     htmllint: {
-      src: 'build//**/*.html'
+      src: 'build/**/*.html'
     }
 
   });


### PR DESCRIPTION
Note that the less plugin outputs wrong path for the sourcemap.

@vladikoff: don't merge this yet; it's a good opportunity to fix the sourcemap issue in grunt-contrib-less.

Currently, I get `/*# sourceMappingURL=build/css/main.css.map */` which is wrong since the sourcemap is in the same folder as the css file.
