### PR TITLE
Fixed social media icons on Firefox and Chrome

### DIFF
--- a/src/less/main.less
+++ b/src/less/main.less
@@ -683,7 +683,7 @@ i {
           &.social a,
           &.social a:hover {
             font-size: 1.3em;
-            padding: .95em .6em;
+            padding: .95em .6em .73em;
             vertical-align: middle;
           }
         }


### PR DESCRIPTION
Fixed hover on footer social media.
See [screenshot](https://dl.dropboxusercontent.com/u/369583/social-grunt-footer.png)