### PR TITLE
Update stable version number on homepage

### DIFF
--- a/src/tmpl/index.pug
+++ b/src/tmpl/index.pug
@@ -117,7 +117,7 @@ block content
             ul
               li Stable:
                 = ' '
-                a(href='https://www.npmjs.org/package/grunt') v1.4.1
+                a(href='https://www.npmjs.org/package/grunt') v1.6.1
                 span  (npm)
               li Development:
                 = ' '


### PR DESCRIPTION
It is currently set to `1.4.1` which might confuse some people.