### PR TITLE
Fix "Grunt"'s spelling.

### DIFF
--- a/src/tmpl/index.pug
+++ b/src/tmpl/index.pug
@@ -44,7 +44,7 @@ block content
 
           .grunt-preview
             h2 Here's a preview!
-            p While installing grunt is simple, it's slightly more involved to get it running on your project. To see what your effort will win you, take a look at this example output from running Grunt in a <a href="https://github.com/cowboy/jquery-tiny-pubsub">sample project</a>.
+            p While installing Grunt is simple, it's slightly more involved to get it running on your project. To see what your effort will win you, take a look at this example output from running Grunt in a <a href="https://github.com/cowboy/jquery-tiny-pubsub">sample project</a>.
             // THX 2 @GF3 4 THE CSS <3!!
             pre.terminal
               span.command-prompt grunt


### PR DESCRIPTION
Fix inconsistent project name in the index page.